### PR TITLE
Do not automatically set pins to output when declaring instance of MC…

### DIFF
--- a/MCP3017AccelStepper.cpp
+++ b/MCP3017AccelStepper.cpp
@@ -9,7 +9,7 @@ MCP3017AccelStepper::MCP3017AccelStepper() {
 }
 
 
-MCP3017AccelStepper::MCP3017AccelStepper(uint8_t interface, uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4) : _accelStepper(interface, pin1, pin2, pin3, pin4) {
+MCP3017AccelStepper::MCP3017AccelStepper(uint8_t interface, uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4) : _accelStepper(interface, pin1, pin2, pin3, pin4, false) {
   _interface = interface;
   _currentPos = 0;
   _targetPos = 0;


### PR DESCRIPTION
…P3017AccelStepper

Current versions of AccelStepper will by default set the provided pins to "output" when instanciating AccelStepper, see below:
```
AccelStepper(uint8_t interface = AccelStepper::FULL4WIRE, uint8_t pin1 = 2, uint8_t pin2 = 3, uint8_t pin3 = 4, uint8_t pin4 = 5, bool enable = true);
(...)
AccelStepper::AccelStepper(uint8_t interface, uint8_t pin1, uint8_t pin2, uint8_t pin3, uint8_t pin4, bool enable)
{
(...)
    if (enable)
	enableOutputs();
    // Some reasonable default
    setAcceleration(1);
}

This change will set `enable = false` before instanciating AccelStepper

I hope this helps other, this was my first time playing around with Arduinos and CPP; it caused immediate rst code 4 when using forbidden pins from my D1 Mini.